### PR TITLE
fixed issue with water effect

### DIFF
--- a/assets/gradients/water_effect_color_ramp.tres
+++ b/assets/gradients/water_effect_color_ramp.tres
@@ -1,7 +1,7 @@
 [gd_resource type="GradientTexture1D" load_steps=2 format=3 uid="uid://dv2unbnfjqv3r"]
 
 [sub_resource type="Gradient" id="Gradient_ydgp0"]
-offsets = PackedFloat32Array(0.506061, 0.99697)
+offsets = PackedFloat32Array(0.506061, 1)
 colors = PackedColorArray(0.231373, 0.462745, 0.54902, 0.639216, 0.231373, 0.462745, 0.54902, 1)
 
 [resource]

--- a/assets/shaders/water_effect.gdshader
+++ b/assets/shaders/water_effect.gdshader
@@ -4,12 +4,13 @@ uniform sampler2D color_ramp;
 varying vec2 world_position;
 
 void vertex() {
-    world_position = (CANVAS_MATRIX * vec4(VERTEX, 1.0, 1.0)).xy;
+    world_position = (MODEL_MATRIX * vec4(VERTEX, 1.0, 1.0)).xy;
 }
 
 vec2 random(vec2 uv) {
 	return vec2(fract(sin(dot(uv.xy,
-		vec2(12.9898,78.233))) * 43758.5453123)) * clamp(0.75+((sin(TIME) +0.0) /4.0f), 0.5, 1.0);
+		vec2(12.9898,78.233))) * 43758.5453123)) * clamp(0.75+((sin(TIME)) /4.0f), 0.5, 1.0);
+        //vec2(12.9898,78.233))) * 43758.5453123));
 }
 
 float worley(vec2 uv, float columns, float rows) {

--- a/scripts/entities/water_effect.gd
+++ b/scripts/entities/water_effect.gd
@@ -1,0 +1,10 @@
+
+
+extends Sprite2D
+
+
+@export var _Player :CharacterBody2D
+
+func _process (delta :float) -> void:
+
+    global_position = _Player.global_position

--- a/scripts/levels/world.tscn
+++ b/scripts/levels/world.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=7 format=3 uid="uid://7pc3dynyj3ax"]
+[gd_scene load_steps=8 format=3 uid="uid://7pc3dynyj3ax"]
 
 [ext_resource type="Shader" path="res://assets/shaders/water_effect.gdshader" id="1_otd8x"]
 [ext_resource type="PackedScene" uid="uid://dgaq2412shtkp" path="res://scenes/entities/player.tscn" id="1_ypafy"]
 [ext_resource type="Texture2D" uid="uid://dv2unbnfjqv3r" path="res://assets/gradients/water_effect_color_ramp.tres" id="2_tbaoy"]
+[ext_resource type="Script" path="res://scripts/entities/water_effect.gd" id="3_d1dyl"]
 [ext_resource type="PackedScene" uid="uid://c6wl8krh5vc0f" path="res://scenes/entities/enemy.tscn" id="3_uxm3w"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_civoq"]
@@ -14,16 +15,11 @@ size = Vector2(1920, 1080)
 
 [node name="Main" type="Node"]
 
-[node name="ParallaxBackground" type="ParallaxBackground" parent="."]
-offset = Vector2(960, 540)
-transform = Transform2D(1, 0, 0, 1, 960, 540)
-
-[node name="ParallaxLayer" type="ParallaxLayer" parent="ParallaxBackground"]
-motion_mirroring = Vector2(1920, 1080)
-
-[node name="Sprite2D" type="Sprite2D" parent="ParallaxBackground/ParallaxLayer"]
+[node name="BackgroundWaterEffect" type="Sprite2D" parent="." node_paths=PackedStringArray("_Player")]
 material = SubResource("ShaderMaterial_civoq")
 texture = SubResource("PlaceholderTexture2D_gclqv")
+script = ExtResource("3_d1dyl")
+_Player = NodePath("../Player")
 
 [node name="Enemy" parent="." instance=ExtResource("3_uxm3w")]
 position = Vector2(1315, 292)


### PR DESCRIPTION
parallax background 'mirrored' effect doesn't use updated world coordinates. fix has background follow player and uses MODEL_MATRIX instead of CANVAS_MATRIX within shader to create static infinite background effect